### PR TITLE
docs: define release policy and runbook

### DIFF
--- a/releases.md
+++ b/releases.md
@@ -1,0 +1,36 @@
+# Tekton Kueue Releases
+
+## Release cadence and support
+
+Tekton Kueue follows the [Tekton release policy](https://github.com/tektoncd/community/blob/main/releases.md) and uses [semantic versioning](https://semver.org/).
+
+A minor release is planned every three months. Each minor release is designated for long-term support (LTS) until the third subsequent minor release is published, which is approximately one year. During that period, patch releases may be issued for CVEs, dependency issues, and critical component issues covered by the Tekton release policy.
+
+The first Tekton Kueue release covered by this policy is planned to be `v0.5.0`. Earlier releases remain available as historical releases but are not covered by this support commitment. Release branch naming will follow the resolution of [#20](https://github.com/tektoncd/tekton-kueue/issues/20) before `v0.5.0` is published.
+
+## Proposed release artifacts
+
+The Tekton-controlled release path is being implemented to publish:
+
+- an immutable `vX.Y.Z` source tag and GitHub release notes;
+- `release.yaml` and `release.notags.yaml` installation manifests;
+- `SHA256SUMS` for the installation manifests;
+- a multi-architecture controller image under `ghcr.io/tektoncd/tekton-kueue`, referenced by digest from the manifests; and
+- image signatures and build provenance produced by Tekton Chains.
+
+Once the release path is deployed, manifests will be stored under `https://infra.tekton.dev/tekton-releases/tekton-kueue/`. See the [release runbook](./tekton/release-cheat-sheet.md) for the operator procedure.
+
+## Planned supported releases
+
+### v0.5 (LTS)
+
+- **Initial release:** `v0.5.0` (planned)
+- **End of life:** when `v0.8.0` is published
+- **Release branch:** selected after the branch convention in [#20](https://github.com/tektoncd/tekton-kueue/issues/20) is resolved
+- **Compatibility:** recorded after the release-candidate test matrix completes
+
+The release date, exact end-of-life date, compatibility ranges, and patch-release links will be recorded when `v0.5.0` is published.
+
+## Historical releases
+
+[`v0.4.0`](https://github.com/tektoncd/tekton-kueue/releases/tag/v0.4.0) and earlier releases used the publication path retained from before the repository transfer. They demonstrate the historical artifact shape but were not produced through Tekton-controlled release infrastructure.

--- a/tekton/release-cheat-sheet.md
+++ b/tekton/release-cheat-sheet.md
@@ -1,0 +1,50 @@
+# Tekton Kueue release runbook
+
+This runbook is for Tekton Kueue release operators. Release policy and support dates are recorded in [`releases.md`](../releases.md).
+
+The automated steps below become operational only after the release Pipeline and its plumbing configuration tracked by [#527](https://github.com/tektoncd/tekton-kueue/issues/527) are merged and deployed.
+
+## Before the release
+
+1. Confirm the target version, LTS designation, end-of-life date, and compatibility ranges with the maintainers.
+2. Confirm all intended changes are merged and their release-note blocks are complete.
+3. From a clean checkout of the candidate commit, run generation, lint, unit, and end-to-end checks.
+4. Run a release candidate with `releaseAsLatest=false` through the Tekton-controlled release Pipeline.
+5. Verify both generated manifests reference only `ghcr.io/tektoncd/tekton-kueue` images by immutable digest.
+6. Install and upgrade the candidate on the supported Kubernetes, Tekton Pipelines, and Kueue versions.
+
+## Publish an initial release
+
+1. Create the policy-defined release branch from the verified commit, using the branch convention selected in [#20](https://github.com/tektoncd/tekton-kueue/issues/20).
+2. Once deployed, Pipelines as Code starts the release Pipeline from `.tekton/release.yaml`.
+3. Monitor the PipelineRun in the `releases-tekton-kueue` namespace.
+4. Review the generated GitHub release notes and verify all publication checks below before publishing the draft.
+
+## Publish a patch release
+
+1. Cherry-pick an approved fix to the supported release branch.
+2. Once deployed, run the **Patch Release** GitHub workflow with the branch, next `vX.Y.Z` version, and whether it should update `latest`.
+3. Monitor and verify the release as for an initial release.
+
+The scheduled patch workflow may detect unreleased commits, but a release operator must still verify the resulting release before announcing it.
+
+## Verify publication
+
+Verify and record:
+
+- the source tag and release branch;
+- the GitHub release and attached `release.yaml`, `release.notags.yaml`, and `SHA256SUMS`;
+- the object-storage copies under `https://infra.tekton.dev/tekton-releases/tekton-kueue/`;
+- the controller image digest and supported architectures;
+- the Tekton Chains signature and Rekor provenance entry; and
+- successful clean installation and upgrade testing.
+
+Do not announce the release until every promised artifact is downloadable and independently verifiable.
+
+## After the release
+
+1. Update [`releases.md`](../releases.md) with the release date, exact end-of-life date, compatibility ranges, and release links.
+2. Close the `vX.Y` milestone if one was used.
+3. Announce the release through the normal Tekton channels.
+
+See the [Tekton signing documentation](https://github.com/tektoncd/plumbing/blob/main/docs/signing.md) for signature and provenance verification.

--- a/tekton/release-cheat-sheet.md
+++ b/tekton/release-cheat-sheet.md
@@ -2,28 +2,28 @@
 
 This runbook is for Tekton Kueue release operators. Release policy and support dates are recorded in [`releases.md`](../releases.md).
 
-The automated steps below become operational only after the release Pipeline and its plumbing configuration tracked by [#527](https://github.com/tektoncd/tekton-kueue/issues/527) are merged and deployed.
+The automated steps below become operational only after the release Pipeline tracked by [#527](https://github.com/tektoncd/tekton-kueue/issues/527) is merged and its plumbing configuration is deployed to the Tekton OCI CI/CD cluster.
 
 ## Before the release
 
 1. Confirm the target version, LTS designation, end-of-life date, and compatibility ranges with the maintainers.
 2. Confirm all intended changes are merged and their release-note blocks are complete.
 3. From a clean checkout of the candidate commit, run generation, lint, unit, and end-to-end checks.
-4. Run a release candidate with `releaseAsLatest=false` through the Tekton-controlled release Pipeline.
+4. Run a release candidate with `releaseAsLatest=false` through the Tekton-controlled release Pipeline so it cannot update the `latest` image tag or artifacts.
 5. Verify both generated manifests reference only `ghcr.io/tektoncd/tekton-kueue` images by immutable digest.
 6. Install and upgrade the candidate on the supported Kubernetes, Tekton Pipelines, and Kueue versions.
 
 ## Publish an initial release
 
 1. Create the policy-defined release branch from the verified commit, using the branch convention selected in [#20](https://github.com/tektoncd/tekton-kueue/issues/20).
-2. Once deployed, Pipelines as Code starts the release Pipeline from `.tekton/release.yaml`.
+2. Creating the release branch in `tektoncd/tekton-kueue` triggers Pipelines as Code in the Tekton OCI CI/CD cluster to start the release Pipeline from the trusted default-branch `.tekton/release.yaml`.
 3. Monitor the PipelineRun in the `releases-tekton-kueue` namespace.
 4. Review the generated GitHub release notes and verify all publication checks below before publishing the draft.
 
 ## Publish a patch release
 
 1. Cherry-pick an approved fix to the supported release branch.
-2. Once deployed, run the **Patch Release** GitHub workflow with the branch, next `vX.Y.Z` version, and whether it should update `latest`.
+2. After the cherry-pick passes CI on the release branch, run the **Patch Release** GitHub workflow with the branch, next `vX.Y.Z` version, and whether it should update `latest`.
 3. Monitor and verify the release as for an initial release.
 
 The scheduled patch workflow may detect unreleased commits, but a release operator must still verify the resulting release before announcing it.


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

- Propose a quarterly LTS cadence beginning with `v0.5.0` and document the support boundary required by the Tekton release policy.
- Define the intended Tekton-controlled image, manifest, checksum, signing, and provenance contract.
- Add an operator runbook while leaving release-branch naming to the resolution of #20.

Part of #527.

/kind documentation

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
