### PR TITLE
Reject negative resource annotation values in quota calculations

### DIFF
--- a/internal/cel/mutator.go
+++ b/internal/cel/mutator.go
@@ -158,6 +158,9 @@ func mutate(pipelineRun *tekv1.PipelineRun, mutation *MutationRequest) (*tekv1.P
 				// This can happen if the user has manually set the value to a non-integer
 				return nil, fmt.Errorf("failed to parse existing resource value %q as integer for key %q: %w", existingValue, mutation.Key, err)
 			}
+			if existingInt < 0 {
+				return nil, fmt.Errorf("negative resource value %q for key %q is not allowed", existingValue, mutation.Key)
+			}
 			newValue += existingInt
 		}
 

--- a/internal/cel/mutator_test.go
+++ b/internal/cel/mutator_test.go
@@ -744,6 +744,21 @@ func TestCELMutator_Mutate(t *testing.T) {
 			errMsg:              "failed to parse existing resource value \"invalid\" as integer",
 		},
 		{
+			name: "resource mutation - negative existing value rejected",
+			expressions: []string{
+				`resource("ibm-vm-z", 500)`,
+			},
+			initialLabels: nil,
+			initialAnnotations: map[string]string{
+				"kueue.konflux-ci.dev/requests-ibm-vm-z": "-100",
+			},
+			expectedLabels:      nil,
+			expectedAnnotations: nil,
+			expectErr:           true,
+			expectedErrType:     new(*EvaluationError),
+			errMsg:              "negative resource value",
+		},
+		{
 			name: "multiple resource mutations - same key summing",
 			expressions: []string{
 				`resource("aws-vm-x", 2)`,

--- a/internal/controller/pipelinerun_controller.go
+++ b/internal/controller/pipelinerun_controller.go
@@ -252,10 +252,20 @@ func (p *PipelineRun) parseResourcesRequestsAnnotation(k, v string) (*corev1.Res
 			fmt.Sprintf("empty resource name in annotation %s", k))
 	}
 
+	if corev1.ResourceName(t) == ResourcePipelineRunCount {
+		return nil, nil, jobframework.UnretryableError(
+			fmt.Sprintf("overriding the concurrency token %q via annotation is not allowed", ResourcePipelineRunCount))
+	}
+
 	q, err := resource.ParseQuantity(v)
 	if err != nil {
 		return nil, nil, jobframework.UnretryableError(
 			fmt.Sprintf("invalid resource quantity in annotation %s=%q: %v", k, v, err))
+	}
+
+	if q.Sign() < 0 {
+		return nil, nil, jobframework.UnretryableError(
+			fmt.Sprintf("negative resource quantity in annotation %s=%q is not allowed", k, v))
 	}
 
 	return ptr.To(corev1.ResourceName(t)), &q, nil

--- a/internal/controller/pipelinerun_controller_test.go
+++ b/internal/controller/pipelinerun_controller_test.go
@@ -341,6 +341,34 @@ var _ = Describe("PipelineRun", func() {
 			))
 			Expect(requests).To(BeNil())
 		})
+
+		It("should return unretryable error when attempting to override the concurrency token", func() {
+			p := newTestPipelineRun(func(plr *tekv1.PipelineRun) {
+				plr.Annotations = map[string]string{
+					"kueue.konflux-ci.dev/requests-tekton.dev/pipelineruns": "0",
+				}
+			})
+			requests, err := p.resourcesRequests()
+			Expect(err).To(And(
+				MatchError(ContainSubstring("overriding the concurrency token")),
+				Satisfy(jobframework.IsUnretryableError),
+			))
+			Expect(requests).To(BeNil())
+		})
+
+		It("should return unretryable error when annotation value is negative", func() {
+			p := newTestPipelineRun(func(plr *tekv1.PipelineRun) {
+				plr.Annotations = map[string]string{
+					"kueue.konflux-ci.dev/requests-cpu": "-1",
+				}
+			})
+			requests, err := p.resourcesRequests()
+			Expect(err).To(And(
+				MatchError(ContainSubstring("negative resource quantity")),
+				Satisfy(jobframework.IsUnretryableError),
+			))
+			Expect(requests).To(BeNil())
+		})
 	})
 
 	Describe("PodSets", func() {


### PR DESCRIPTION
## Summary
- Cherry-pick of [`60640da`](https://github.com/tektoncd/tekton-kueue/commit/60640da63c74274a360e2ac905f498c9f08cdab1) onto `release-v0.4.x`
- Reject negative pre-existing `resource()` annotation values in the CEL mutator
- Reject negative resource quantities in the controller, and block override of the `tekton.dev/pipelineruns` concurrency token

## Why
The v0.4.x line still accepts negative `kueue.konflux-ci.dev/requests-*` annotations, which can cancel out admin-mandated resource costs and bypass ClusterQueue admission limits. This backports the fix already on `main`.

## Test plan
- [x] Cherry-pick applied cleanly
- [x] `golangci-lint run ./internal/cel/ ./internal/controller/` passes
- [x] `go test ./internal/cel/ ./internal/controller/` passes

# Submitter Checklist
- [x] Has Tests included if any functionality added or changed
- [x] Follows the commit message standard
- [x] Meets the Tekton contributor standards
- [ ] Has a kind label (`/kind bug`)
- [x] Release notes block below has been updated

# Release Notes

```release-note
Reject negative kueue.konflux-ci.dev/requests-* annotation values and block override of the tekton.dev/pipelineruns concurrency token
```


Made with [Cursor](https://cursor.com)