### PR TITLE
chore: add tekton-multicluster-team to OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -2,3 +2,4 @@
 
 approvers:
 - konflux-infra-team
+- tekton-multicluster-team

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,4 +1,8 @@
 aliases:
+    tekton-multicluster-team:
+        - pramodbindal
+        - khrm
+        - waveywaves
     konflux-infra-team:
         - celeztyne
         - enkeefe00


### PR DESCRIPTION
## What

- Add a `tekton-multicluster-team` alias in `OWNERS_ALIASES` with `pramodbindal`, `khrm`, and `waveywaves`.
- List `tekton-multicluster-team` as an approver group in `OWNERS`, alongside `konflux-infra-team`.

## Why

Gives the Tekton multicluster team approval rights on this repository.

## Verification

- [x] Metadata-only change — no code, CEL, API types, or RBAC markers touched, so no build/test impact.
- [x] `OWNERS_ALIASES` parses as valid YAML.